### PR TITLE
Feature: Capture action screenshot and send to save_demo endpoint

### DIFF
--- a/examples/recorder-crx/src/crxRecorder.tsx
+++ b/examples/recorder-crx/src/crxRecorder.tsx
@@ -27,7 +27,7 @@ import { APIKeyInputScreen } from './apiKeyInputScreen';
 import './apiKeyInputScreen.css';
 
 // Global Maps to store eval pages and contents
-const globalEvalPages = new Map<string, { [key: string]: any }>();
+const globalEvalPages = new Map<string, { eval_page: any; screenshot?: string }>();
 // const globalContents = new Map<string, string>();
 
 function setElementPicked(elementInfo: ElementInfo, userGesture?: boolean) {
@@ -95,7 +95,10 @@ export const CrxRecorder: React.FC = ({
       if (message.type === 'OPTEXITY_EVAL_PAGE') {
         (async () => {
           if (message.eval_page) {
-            globalEvalPages.set(message.file_id, message.eval_page);
+            globalEvalPages.set(message.file_id, {
+              eval_page: message.eval_page,
+              screenshot: message.screenshot // This will be undefined if no screenshot was captured
+            });
             // globalContents.set(message.file_id, message.content);
             sendResponse({ success: true });
           } else {

--- a/playwright/packages/injected/src/recorder/recorder.ts
+++ b/playwright/packages/injected/src/recorder/recorder.ts
@@ -1084,6 +1084,7 @@ export class Recorder {
       addEventListener(this.document, 'contextmenu', event => this._onContextMenu(event as MouseEvent), true),
       addEventListener(this.document, 'dragstart', event => this._onDragStart(event as DragEvent), true),
       addEventListener(this.document, 'input', event => this._onInput(event), true),
+      addEventListener(this.document, 'change', event => this._onInput(event), true),
       addEventListener(this.document, 'keydown', event => this._onKeyDown(event as KeyboardEvent), true),
       addEventListener(this.document, 'keyup', event => this._onKeyUp(event as KeyboardEvent), true),
       addEventListener(this.document, 'pointerdown', event => this._onPointerDown(event as PointerEvent), true),

--- a/playwright/packages/playwright-core/src/server/recorder/contextRecorder.ts
+++ b/playwright/packages/playwright-core/src/server/recorder/contextRecorder.ts
@@ -37,6 +37,7 @@ import type * as channels from '@protocol/channels';
 import type * as actions from '@recorder/actions';
 import type { Source, SourceHighlight } from '@recorder/recorderTypes';
 import { useEffect } from 'react';
+import { serverSideCallMetadata } from '../instrumentation';
 
 type BindingSource = { frame: Frame, page: Page };
 
@@ -109,16 +110,18 @@ export class ContextRecorder extends EventEmitter {
         if (languageGenerator === this._orderedLanguages[0])
           this._throttledOutputFile?.setContent(source.text);
       }
-      try{
+      try {
+        const lastAction = actions[actions.length - 1];
         chrome.runtime.sendMessage({
           type: 'OPTEXITY_EVAL_PAGE',
-          eval_page: actions[actions.length - 1].eval_page,
-          // content: actions[actions.length - 1].content,
-            file_id: actions[actions.length - 1].uuid,
-          });
+          eval_page: lastAction.eval_page,
+          file_id: lastAction.uuid,
+          screenshot: lastAction.screenshot,
+        });
       } catch (error) {
-        console.log('error in generateCode : ', error);
+        console.error('Failed to send action data:', error);
       }
+    
       this.emit(ContextRecorder.Events.Change, {
         sources: this._recorderSources,
         actions
@@ -302,15 +305,17 @@ export class ContextRecorder extends EventEmitter {
     const _uuid = timestamp.toString() + '_' + Math.random().toString(36).substring(2, 15);
     const frameDescription = await this._describeFrame(frame);
     const { content, eval_page } = await this.get_eval_page(frame);
-    console.log('--------------------------------')
-    console.log('action in _createActionInContext : ', action);
 
+    // Capture screenshot of the page at action time
+    let screenshot: string | undefined;
     try {
-      console.log('selector in _createActionInContext : ', action.selector);
+      const page = frame._page;
+      const screenshotBuffer = await page.screenshot(serverSideCallMetadata(), { type: 'png', fullPage: false });
+      screenshot = screenshotBuffer.toString('base64');
     } catch (e) {
-      console.log('Error: ', e);
+      console.error('Error capturing screenshot:', e);
     }
-    // console.log('eval_page : ', eval_page);
+
     const actionInContext: actions.ActionInContext = {
       frame: frameDescription,
       action,
@@ -319,6 +324,7 @@ export class ContextRecorder extends EventEmitter {
       uuid: _uuid,
       content: content,
       eval_page: eval_page,
+      screenshot,
     };
     await this._delegate.rewriteActionInContext?.(this._pageAliases, actionInContext);
     return actionInContext;

--- a/playwright/packages/recorder/src/actions.d.ts
+++ b/playwright/packages/recorder/src/actions.d.ts
@@ -171,4 +171,5 @@ export type ActionInContext = {
   content?: string;
   eval_page?: { [key: string]: any };
   optexityBid?: string;
+  screenshot?: string;
 };


### PR DESCRIPTION


## Changes

1. **Record `<select>` interactions correctly**
   Previously, the recorder only listened for `input` events. However, `<select>` elements emit `change` events, so dropdown selections were not being captured.
   Added a `change` event listener (capture phase) that routes to the existing `_onInput` handler. This ensures `<select>` actions are recorded properly without modifying downstream logic or code generation behavior.

2. **Attach page screenshot to each action**
   A page screenshot is now captured at the time of each action and stored as a base64 string on the action object.
   The latest action’s `eval_page`, `uuid`, and `screenshot` are sent via `chrome.runtime.sendMessage` using the `OPTEXITY_EVAL_PAGE` message type.


